### PR TITLE
feat(UI): remove generate classes from UI

### DIFF
--- a/ScriptBeeClient/src/app/pages/projects/project-details/analysis/script-tree/script-tree.component.html
+++ b/ScriptBeeClient/src/app/pages/projects/project-details/analysis/script-tree/script-tree.component.html
@@ -1,12 +1,4 @@
 <div class="create-new-script-container">
-  <button
-    mat-icon-button
-    aria-label="generate classes"
-    matTooltip="Generate Classes"
-    (click)="onGenerateClassesClick()"
-    [disabled]="!projectStateService.currentInstanceId()">
-    <mat-icon>data_object</mat-icon>
-  </button>
   <button mat-icon-button aria-label="reload tree" matTooltip="Reload tree" (click)="onReloadTreeButtonClick()">
     <mat-icon>sync</mat-icon>
   </button>
@@ -17,10 +9,6 @@
 
 @if (isDeleteLoading()) {
   <app-loading-progress-bar title="Deleting..."></app-loading-progress-bar>
-}
-
-@if (isGenerateClassesLoading()) {
-  <app-loading-progress-bar title="Generating classes..."></app-loading-progress-bar>
 }
 
 <app-lazy-file-tree

--- a/ScriptBeeClient/src/app/pages/projects/project-details/analysis/script-tree/script-tree.component.spec.ts
+++ b/ScriptBeeClient/src/app/pages/projects/project-details/analysis/script-tree/script-tree.component.spec.ts
@@ -173,30 +173,6 @@ describe('ScriptTreeComponent', () => {
 
       expect(fileSelectedSpy).toHaveBeenCalledWith(file);
     });
-
-    it('should generate classes when generate classes button is clicked', () => {
-      fixture.componentRef.setInput('projectId', 'project-abc');
-      fixture.detectChanges();
-      const generateButton = fixture.debugElement.query(By.css('button[aria-label="generate classes"]'));
-
-      generateButton.nativeElement.click();
-
-      expect(projectContextService.generateClasses).toHaveBeenCalledWith('project-abc', 'instance-123');
-      expect(snackbar.open).toHaveBeenCalledWith('Successfully generated model classes', 'Dismiss', expect.anything());
-    });
-
-    it('should show error when generate classes fails', () => {
-      fixture.componentRef.setInput('projectId', 'project-abc');
-      const httpError = new HttpErrorResponse({ error: { title: 'Unknown Error', status: 500 }, status: 500 });
-      projectContextService.generateClasses.mockReturnValue(throwError(() => httpError));
-      fixture.detectChanges();
-      const generateButton = fixture.debugElement.query(By.css('button[aria-label="generate classes"]'));
-
-      generateButton.nativeElement.click();
-
-      expect(projectContextService.generateClasses).toHaveBeenCalledWith('project-abc', 'instance-123');
-      expect(snackbar.open).toHaveBeenCalledWith(expect.stringContaining('Unknown Error'), 'Dismiss', expect.anything());
-    });
   });
 
   describe('Actions', () => {

--- a/ScriptBeeClient/src/app/pages/projects/project-details/analysis/script-tree/script-tree.component.ts
+++ b/ScriptBeeClient/src/app/pages/projects/project-details/analysis/script-tree/script-tree.component.ts
@@ -14,8 +14,6 @@ import { TreeAction, TreeNode } from '../../../../../types/tree-node';
 import { RenameFileDialog } from '../../../../../components/dialogs/rename-file-dialog/rename-file-dialog.component';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { ProjectContextService } from '../../../../../services/projects/project-context.service';
-import { ProjectStateService } from '../../../../../services/projects/project-state.service';
 
 @Component({
   selector: 'app-script-tree',
@@ -30,7 +28,6 @@ export class ScriptTreeComponent {
   fileSelected = output<ProjectFileNode>();
 
   isDeleteLoading = signal(false);
-  isGenerateClassesLoading = signal(false);
 
   lazyTree = viewChild.required(LazyFileTreeComponent<ProjectFileNode>);
 
@@ -57,8 +54,6 @@ export class ScriptTreeComponent {
   private projectStructureService = inject(ProjectStructureService);
   private dialog = inject(MatDialog);
   private snackbar = inject(MatSnackBar);
-  private projectContextService = inject(ProjectContextService);
-  projectStateService = inject(ProjectStateService);
 
   fetchData = (parentId: string | null, offset: number, limit: number) => {
     return this.projectStructureService.getProjectFiles(this.projectId(), parentId || undefined, offset, limit).pipe(
@@ -87,28 +82,6 @@ export class ScriptTreeComponent {
 
   onReloadTreeButtonClick() {
     this.lazyTree().resetTree();
-  }
-
-  onGenerateClassesClick() {
-    const instanceId = this.projectStateService.currentInstanceId();
-    if (!instanceId) {
-      this.snackbar.open('Cannot generate classes without an active instance', 'Dismiss', { duration: 4000 });
-      return;
-    }
-
-    this.isGenerateClassesLoading.set(true);
-    this.projectContextService
-      .generateClasses(this.projectId(), instanceId)
-      .pipe(finalize(() => this.isGenerateClassesLoading.set(false)))
-      .subscribe({
-        next: () => {
-          this.snackbar.open('Successfully generated model classes', 'Dismiss', { duration: 4000 });
-        },
-        error: (errorResponse: HttpErrorResponse) => {
-          const error = convertError(errorResponse);
-          this.snackbar.open(`Could not generate classes because ${error?.title}`, 'Dismiss', { duration: 4000 });
-        },
-      });
   }
 
   private deleteNode(node: ProjectFileNode) {

--- a/ScriptBeeClient/src/app/pages/projects/project-details/model/context-model-page/project-context/project-context.component.html
+++ b/ScriptBeeClient/src/app/pages/projects/project-details/model/context-model-page/project-context/project-context.component.html
@@ -17,16 +17,10 @@
     <app-loading-progress-bar title="Reloading Context..."></app-loading-progress-bar>
   }
 
-  @if (isGenerateClassesLoading()) {
-    <app-loading-progress-bar title="Generating Classes..."></app-loading-progress-bar>
-  }
-
   <app-selectable-tree [data]="context()" [displayNameAccessor]="displayNameAccessor"></app-selectable-tree>
 
   <div class="action-buttons-container">
     <button mat-flat-button [disabled]="isReloadContextLoading()" (click)="onReloadModelsClick()">Reload Models</button>
-
-    <button mat-flat-button [disabled]="isGenerateClassesLoading()" (click)="onGenerateClassesClick()">Generate Classes</button>
 
     <button mat-flat-button [disabled]="isClearContextLoading()" (click)="onClearContextButtonClick()">Clear Context</button>
   </div>

--- a/ScriptBeeClient/src/app/pages/projects/project-details/model/context-model-page/project-context/project-context.component.spec.ts
+++ b/ScriptBeeClient/src/app/pages/projects/project-details/model/context-model-page/project-context/project-context.component.spec.ts
@@ -48,15 +48,8 @@ describe('ProjectContextComponent', () => {
     expect(projectContextService.reloadContext).toHaveBeenCalledWith('proj-1', 'inst-1');
   });
 
-  it('should call generateClasses when generate button is clicked', () => {
-    const generateButton = fixture.debugElement.query(By.css('button:nth-child(2)'));
-    generateButton.nativeElement.click();
-
-    expect(projectContextService.generateClasses).toHaveBeenCalledWith('proj-1', 'inst-1');
-  });
-
   it('should call clearContext when clear button is clicked', () => {
-    const clearButton = fixture.debugElement.query(By.css('button:nth-child(3)'));
+    const clearButton = fixture.debugElement.query(By.css('button:nth-child(2)'));
     clearButton.nativeElement.click();
 
     expect(projectContextService.clearContext).toHaveBeenCalledWith('proj-1', 'inst-1');

--- a/ScriptBeeClient/src/app/pages/projects/project-details/model/context-model-page/project-context/project-context.component.ts
+++ b/ScriptBeeClient/src/app/pages/projects/project-details/model/context-model-page/project-context/project-context.component.ts
@@ -34,7 +34,6 @@ export class ProjectContextComponent {
 
   isClearContextLoading = signal(false);
   isReloadContextLoading = signal(false);
-  isGenerateClassesLoading = signal(false);
 
   private projectContextService = inject(ProjectContextService);
 
@@ -52,14 +51,6 @@ export class ProjectContextComponent {
       .clearContext(this.projectId(), this.instanceId())
       .pipe(finalize(() => this.isClearContextLoading.set(false)))
       .subscribe({ next: () => this.projectContextResource.reload() });
-  }
-
-  onGenerateClassesClick() {
-    this.isGenerateClassesLoading.set(true);
-    this.projectContextService
-      .generateClasses(this.projectId(), this.instanceId())
-      .pipe(finalize(() => this.isGenerateClassesLoading.set(false)))
-      .subscribe();
   }
 }
 

--- a/ScriptBeeClient/src/app/services/projects/project-context.service.ts
+++ b/ScriptBeeClient/src/app/services/projects/project-context.service.ts
@@ -24,8 +24,4 @@ export class ProjectContextService {
   reloadContext(projectId: string, instanceId: string) {
     return this.http.post<void>(`/api/projects/${projectId}/instances/${instanceId}/context/reload`, {});
   }
-
-  generateClasses(projectId: string, instanceId: string) {
-    return this.http.post<void>(`/api/projects/${projectId}/instances/${instanceId}/context/generate-classes`, {});
-  }
 }


### PR DESCRIPTION
Since the VS Code extension is in place, we don't need that generate classes in the UI anymore. The user won't have access anymore to the internal file system and that generate classes doesn't make sense anymore as is

closes #169 